### PR TITLE
Fixed authenticating against zero length password.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,24 @@
 
 If your interface is **not** eth0 please specify it, when you call *psl.py*.
 
-##Example:
+# Examples
+
+Gives an overview of all available options
+
+    ./psl.py --help
+
+Discover all ProSafe switches on the local network
 
     ./psl.py --interface eth1 discover
 
-    ./psl.py --help gives an overview over all available options
+Set 802.1Q VLAN VID for port 4 to 1
+
+    ./psl-cli.py  set --passwd "password" --mac B0:B9:8A:57:F6:56 --vlan_pvid 4 1
+
+Query all ports for their 802.1Q VLAN port VID
+
+    ./psl-cli.py query --mac B0:B9:8A:57:F6:56 vlan_pvid
+
 
 # Help wanted
 

--- a/psl_class.py
+++ b/psl_class.py
@@ -360,7 +360,7 @@ class ProSafeLinux:
                     _hashkey = "NtgrSmartSwitchRock"
                     _plainpass = cmddict[self.CMD_PASSWORD]
                     _password = ""
-                    for i in range(len(_password)):
+                    for i in range(len(_plainpass)):
                         _password += chr(ord(_plainpass[i]) ^ ord(_hashkey[i]))
                 else:
                     _password = cmddict[self.CMD_PASSWORD]


### PR DESCRIPTION
The incorrect variable “_password” is being used instead of “_plainpass” on line 363 of psl_class.py. This meant an empty password was being used to authenticate with the switch instead of the password passed as a parameter on the command line.

README.md updated with a couple of additional usage examples.