### PR TITLE
Add unicast receive capability. Add MacOS support. Make both Linux & MacOS work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
+# ProSafeLinux (psl-cli.py)
 
-If your interface is **not** eth0 please specify it, when you call *psl.py*.
+Query and set data on GS105E and GS108E Netgear ProSafe switches.
+
+These are known to work:
+ * GS105E 1.02.04
+ * GS108Ev2 1.00.12
+ * GS108Ev3 2.06.08EN (replies come via unicast)
+
+# Using psl-cli.py
+
+     usage: psl-cli.py [-h] [--interface INTERFACE] [--debug]
+                   [--timeout TIMEOUT]
+                   {discover,exploit,query,query_raw,set} ...
+
+ * Older switch firmware (before 2018?) returns responses to the broadcast address.
+ * Newer switch firmware (after 2018?) return responses to the sender.
+ * If your interface is **not** eth0 please specify it, when you call *psl.py*.
 
 # Examples
 
@@ -19,12 +35,30 @@ Query all ports for their 802.1Q VLAN port VID
 
     ./psl-cli.py query --mac B0:B9:8A:57:F6:56 vlan_pvid
 
+# Dependencies
+
+Required for cross-platform support of MacOS & Linux.
+ - pip install netifaces
+
+# Supported Platforms
+
+"discover" and "query" were recently tested on
+ * MacOS 10.15 with python 2.7
+ * Raspbian Linux 4.19.66-v7+ with python 2.7
+
+# Known issues
+
+Discovery only identifies the first switch that answers.
+
+Newer switches that have web servers may have "Switch Management Mode" set to "Web browser only", which will result in the switch only responding to discovery requests. To use this software, you may login to the web UI and set "Switch Management Mode" to "Web browser and Plus Utility".
+
+"query all" sometimes produces inconsistent results. More reliable responses seem to occur when you query one item at at time.
 
 # Help wanted
 
-Im sorry I am not active at this project anymore. It is open-source so perhabs you could find soneone who can help you.
+Im sorry I am not active at this project anymore. It is open-source so perhaps you could find soneone who can help you.
  
-I have found a security problem with this switch and was very disapointed in the answer from netgear. They need more than 6 Month to fix it and want the ethernet adress of it 
+I have found a security problem with this switch and was very disappointed in the answer from netgear. They need more than 6 Month to fix it and want the ethernet adress of it
  
 Because of this, I do not use this switch anymore.
  
@@ -32,7 +66,7 @@ If you can read german, please read this two articles:
  
 http://www.linux-magazin.de/Blogs/Insecurity-Bulletin/Gastbeitrag-Security-by-Obscurity-bei-Netgear-Switches
 http://www.linux-magazin.de/Ausgaben/2012/10/Switch
- 
+
 Please feel free to fork the code and do any push request.
 
 Please contact me if you like to do the new maintainer of the projekt Sven Anders &lt;psl-github2013@sven.anders.im&gt;
@@ -48,6 +82,7 @@ https://github.com/Z3po/Netgearizer (We are merging code together.)
 * Svenne Krap
 * Shane Kerr
 * Sven Anders
+* Steven Bytnar
 
 See also: http://git.asbjorn.biz/?p=gs105e.git;a=summary
 


### PR DESCRIPTION
Works for me. :-)
Verified "discover" and "query" on MacOS & Raspbian. Made some notes in Known issues about inconsistent behavior.
Did not verify "set".
Some changes to README to describe the project better.
Q: Is socket.SO_REUSEPORT really necessary? A: I enabled it in earlier passes to get earlier MacOS changes working, and left it in when I found it worked on Linux & MacOS. Doesn't hurt?
The unicast changes may address: https://github.com/tabacha/ProSafeLinux/issues/33#issuecomment-711144598